### PR TITLE
Add Gravity Sketch MCP tool support

### DIFF
--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -29,6 +29,7 @@ mod json_to_toml;
 pub(crate) mod message_processor;
 mod outgoing_message;
 mod patch_approval;
+mod tool_handlers;
 
 use crate::message_processor::MessageProcessor;
 use crate::outgoing_message::OutgoingMessage;
@@ -40,6 +41,8 @@ pub use crate::exec_approval::ExecApprovalElicitRequestParams;
 pub use crate::exec_approval::ExecApprovalResponse;
 pub use crate::patch_approval::PatchApprovalElicitRequestParams;
 pub use crate::patch_approval::PatchApprovalResponse;
+pub use crate::tool_handlers::gravity_sketch::GravitySketchAction;
+pub use crate::tool_handlers::gravity_sketch::GravitySketchToolCallParam;
 
 /// Size of the bounded channels used to communicate between tasks. The value
 /// is a balance between throughput and memory usage – 128 messages should be

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -8,6 +8,8 @@ use crate::codex_tool_config::create_tool_for_codex_tool_call_param;
 use crate::codex_tool_config::create_tool_for_codex_tool_call_reply_param;
 use crate::error_code::INVALID_REQUEST_ERROR_CODE;
 use crate::outgoing_message::OutgoingMessageSender;
+use crate::tool_handlers::gravity_sketch::create_tool_for_gravity_sketch;
+use crate::tool_handlers::gravity_sketch::handle_tool_call_gravity_sketch;
 use codex_protocol::mcp_protocol::ClientRequest;
 use codex_protocol::mcp_protocol::ConversationId;
 
@@ -322,6 +324,7 @@ impl MessageProcessor {
             tools: vec![
                 create_tool_for_codex_tool_call_param(),
                 create_tool_for_codex_tool_call_reply_param(),
+                create_tool_for_gravity_sketch(),
             ],
             next_cursor: None,
         };
@@ -343,6 +346,9 @@ impl MessageProcessor {
             "codex-reply" => {
                 self.handle_tool_call_codex_session_reply(id, arguments)
                     .await
+            }
+            "gravity-sketch" => {
+                handle_tool_call_gravity_sketch(self.outgoing.clone(), id, arguments).await;
             }
             _ => {
                 let result = CallToolResult {

--- a/codex-rs/mcp-server/src/tool_handlers/gravity_sketch.rs
+++ b/codex-rs/mcp-server/src/tool_handlers/gravity_sketch.rs
@@ -1,0 +1,439 @@
+use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+
+use anyhow::Context;
+use anyhow::Result;
+use mcp_types::CallToolResult;
+use mcp_types::ContentBlock;
+use mcp_types::RequestId;
+use mcp_types::TextContent;
+use mcp_types::Tool;
+use mcp_types::ToolInputSchema;
+use schemars::JsonSchema;
+use schemars::r#gen::SchemaSettings;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::json;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::process::Command;
+use tokio::task;
+use tracing::error;
+
+use crate::outgoing_message::OutgoingMessageSender;
+use crate::outgoing_message::OutgoingNotification;
+use crate::outgoing_message::OutgoingNotificationMeta;
+use crate::outgoing_message::OutgoingNotificationParams;
+
+/// Default command used to invoke the Gravity Sketch CLI when no override is supplied.
+const DEFAULT_GRAVITY_SKETCH_CLI: &str = "gravity-sketch-cli";
+
+/// Describes the supported Gravity Sketch operations that can be triggered via the MCP tool.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum GravitySketchAction {
+    /// Launch or focus the Gravity Sketch application.
+    Launch,
+    /// Open an existing scene by id.
+    OpenScene,
+    /// Export the active scene to a local file.
+    ExportScene,
+    /// Import an asset or scene file into Gravity Sketch.
+    ImportAsset,
+    /// Execute a custom CLI subcommand with additional arguments.
+    CustomCommand,
+}
+
+impl GravitySketchAction {
+    fn as_display_name(&self) -> &'static str {
+        match self {
+            Self::Launch => "launch",
+            Self::OpenScene => "open-scene",
+            Self::ExportScene => "export-scene",
+            Self::ImportAsset => "import-asset",
+            Self::CustomCommand => "custom-command",
+        }
+    }
+}
+
+/// Parameters accepted by the `gravity-sketch` MCP tool.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GravitySketchToolCallParam {
+    /// Action to execute.
+    pub action: GravitySketchAction,
+
+    /// Gravity Sketch host. Defaults to `127.0.0.1` when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+
+    /// Gravity Sketch API port. Defaults to the CLI default when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+
+    /// Authentication token injected into the child process via `GRAVITY_SKETCH_TOKEN`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+
+    /// Optional project identifier used by some commands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+
+    /// Scene identifier for `open-scene`/`export-scene`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scene_id: Option<String>,
+
+    /// Local file used when exporting a scene.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub export_path: Option<PathBuf>,
+
+    /// Local path of an asset/scene to import.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub import_path: Option<PathBuf>,
+
+    /// Extra CLI arguments appended after the action.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_args: Vec<String>,
+
+    /// JSON payload forwarded to the CLI via `--payload`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+
+    /// Override the CLI executable used to reach Gravity Sketch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cli_path: Option<PathBuf>,
+
+    /// Additional environment variables for the launched process.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+}
+
+impl GravitySketchToolCallParam {
+    fn resolve_cli_path(&self) -> PathBuf {
+        if let Some(path) = &self.cli_path {
+            return path.clone();
+        }
+        if let Some(path) = env::var("GRAVITY_SKETCH_CLI")
+            .ok()
+            .filter(|path| !path.is_empty())
+        {
+            return PathBuf::from(path);
+        }
+        PathBuf::from(DEFAULT_GRAVITY_SKETCH_CLI)
+    }
+
+    fn configure_command(&self, command: &mut Command) -> Result<()> {
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        command.stdin(Stdio::null());
+
+        if let Some(host) = &self.host {
+            command.arg("--host").arg(host);
+        }
+        if let Some(port) = self.port {
+            command.arg("--port").arg(port.to_string());
+        }
+        if let Some(project_id) = &self.project_id {
+            command.arg("--project-id").arg(project_id);
+        }
+        if let Some(token) = &self.token {
+            command.env("GRAVITY_SKETCH_TOKEN", token);
+        }
+        for (key, value) in &self.env {
+            command.env(key, value);
+        }
+
+        match self.action {
+            GravitySketchAction::Launch => {
+                command.arg("launch");
+            }
+            GravitySketchAction::OpenScene => {
+                let scene_id = self
+                    .scene_id
+                    .as_ref()
+                    .context("`scene_id` is required for the open-scene action")?;
+                command.arg("open-scene").arg("--scene-id").arg(scene_id);
+            }
+            GravitySketchAction::ExportScene => {
+                let scene_id = self
+                    .scene_id
+                    .as_ref()
+                    .context("`scene_id` is required for the export-scene action")?;
+                let export_path = self
+                    .export_path
+                    .as_ref()
+                    .context("`export_path` is required for the export-scene action")?;
+                command
+                    .arg("export-scene")
+                    .arg("--scene-id")
+                    .arg(scene_id)
+                    .arg("--output")
+                    .arg(export_path);
+            }
+            GravitySketchAction::ImportAsset => {
+                let import_path = self
+                    .import_path
+                    .as_ref()
+                    .context("`import_path` is required for the import-asset action")?;
+                command.arg("import-asset").arg(import_path);
+            }
+            GravitySketchAction::CustomCommand => {
+                if self.extra_args.is_empty() {
+                    anyhow::bail!(
+                        "`extra_args` must contain at least one argument for the custom-command action"
+                    );
+                }
+                command.arg("run");
+                for arg in &self.extra_args {
+                    command.arg(arg);
+                }
+            }
+        }
+
+        if let Some(payload) = &self.payload {
+            let payload = serde_json::to_string(payload)?;
+            command.arg("--payload").arg(payload);
+        }
+
+        Ok(())
+    }
+}
+
+/// Builds the JSON schema describing the `gravity-sketch` MCP tool.
+pub(crate) fn create_tool_for_gravity_sketch() -> Tool {
+    let schema = SchemaSettings::draft2019_09()
+        .with(|settings| {
+            settings.inline_subschemas = true;
+            settings.option_add_null_type = false;
+        })
+        .into_generator()
+        .into_root_schema_for::<GravitySketchToolCallParam>();
+
+    #[expect(clippy::expect_used)]
+    let schema_value =
+        serde_json::to_value(&schema).expect("Gravity Sketch tool schema should serialize to JSON");
+
+    let tool_input_schema =
+        serde_json::from_value::<ToolInputSchema>(schema_value).unwrap_or_else(|error| {
+            panic!("failed to create Gravity Sketch tool schema: {error}");
+        });
+
+    Tool {
+        name: "gravity-sketch".to_string(),
+        title: Some("Gravity Sketch".to_string()),
+        description: Some(
+            "Control a local Gravity Sketch instance via its command line interface.".to_string(),
+        ),
+        input_schema: tool_input_schema,
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+/// Handle a `tools/call` invocation for the `gravity-sketch` tool.
+pub(crate) async fn handle_tool_call_gravity_sketch(
+    outgoing: Arc<OutgoingMessageSender>,
+    request_id: RequestId,
+    arguments: Option<serde_json::Value>,
+) {
+    let params = match arguments {
+        Some(value) => match serde_json::from_value::<GravitySketchToolCallParam>(value) {
+            Ok(params) => params,
+            Err(err) => {
+                let result = CallToolResult {
+                    content: vec![ContentBlock::TextContent(TextContent {
+                        r#type: "text".to_owned(),
+                        text: format!(
+                            "Failed to parse configuration for gravity-sketch tool: {err}"
+                        ),
+                        annotations: None,
+                    })],
+                    is_error: Some(true),
+                    structured_content: None,
+                };
+                outgoing.send_response(request_id, result).await;
+                return;
+            }
+        },
+        None => {
+            let result = CallToolResult {
+                content: vec![ContentBlock::TextContent(TextContent {
+                    r#type: "text".to_owned(),
+                    text: "Missing arguments for gravity-sketch tool-call.".to_owned(),
+                    annotations: None,
+                })],
+                is_error: Some(true),
+                structured_content: None,
+            };
+            outgoing.send_response(request_id, result).await;
+            return;
+        }
+    };
+
+    let outgoing_for_task = outgoing.clone();
+    task::spawn(async move {
+        let action = params.action.clone();
+        let result =
+            run_gravity_sketch(params, outgoing_for_task.clone(), request_id.clone()).await;
+
+        match result {
+            Ok(result) => {
+                outgoing_for_task.send_response(request_id, result).await;
+            }
+            Err(err) => {
+                error!("gravity-sketch action {action:?} failed: {err}");
+                let result = CallToolResult {
+                    content: vec![ContentBlock::TextContent(TextContent {
+                        r#type: "text".to_owned(),
+                        text: format!(
+                            "Failed to execute gravity-sketch action {}: {err}",
+                            action.as_display_name()
+                        ),
+                        annotations: None,
+                    })],
+                    is_error: Some(true),
+                    structured_content: None,
+                };
+                outgoing_for_task.send_response(request_id, result).await;
+            }
+        }
+    });
+}
+
+async fn run_gravity_sketch(
+    params: GravitySketchToolCallParam,
+    outgoing: Arc<OutgoingMessageSender>,
+    request_id: RequestId,
+) -> Result<CallToolResult> {
+    let cli_path = params.resolve_cli_path();
+    let mut command = Command::new(&cli_path);
+    params.configure_command(&mut command)?;
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to spawn Gravity Sketch CLI at {cli_path:?}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .context("failed to capture stdout from Gravity Sketch CLI")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("failed to capture stderr from Gravity Sketch CLI")?;
+
+    let stdout_handle = {
+        let outgoing = outgoing.clone();
+        let request_id = request_id.clone();
+        task::spawn(async move { drain_stream(stdout, "stdout", outgoing, request_id).await })
+    };
+    let stderr_handle = {
+        let outgoing = outgoing.clone();
+        let request_id = request_id.clone();
+        task::spawn(async move { drain_stream(stderr, "stderr", outgoing, request_id).await })
+    };
+
+    let status = child
+        .wait()
+        .await
+        .context("failed to wait for Gravity Sketch CLI")?;
+    let stdout_output = stdout_handle.await??;
+    let stderr_output = stderr_handle.await??;
+
+    let summary_text = if status.success() {
+        if stdout_output.trim().is_empty() {
+            format!(
+                "Gravity Sketch action {} completed successfully.",
+                params.action.as_display_name()
+            )
+        } else {
+            stdout_output.clone()
+        }
+    } else {
+        let mut msg = format!(
+            "Gravity Sketch action {} failed with status {}.",
+            params.action.as_display_name(),
+            status
+        );
+        if !stderr_output.trim().is_empty() {
+            msg.push_str("\nstderr:\n");
+            msg.push_str(&stderr_output);
+        } else if !stdout_output.trim().is_empty() {
+            msg.push_str("\nstdout:\n");
+            msg.push_str(&stdout_output);
+        }
+        msg
+    };
+
+    let structured_content = json!({
+        "action": params.action.as_display_name(),
+        "success": status.success(),
+        "status_code": status.code(),
+        "stdout": stdout_output,
+        "stderr": stderr_output,
+    });
+
+    Ok(CallToolResult {
+        content: vec![ContentBlock::TextContent(TextContent {
+            r#type: "text".to_owned(),
+            text: summary_text,
+            annotations: None,
+        })],
+        is_error: Some(!status.success()),
+        structured_content: Some(structured_content),
+    })
+}
+
+async fn drain_stream<R>(
+    reader: R,
+    stream: &'static str,
+    outgoing: Arc<OutgoingMessageSender>,
+    request_id: RequestId,
+) -> Result<String>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    let mut reader = BufReader::new(reader).lines();
+    let mut lines = Vec::new();
+
+    while let Some(line) = reader.next_line().await? {
+        if !line.is_empty() {
+            send_stream_notification(&outgoing, &request_id, stream, &line).await;
+        }
+        lines.push(line);
+    }
+
+    Ok(lines.join("\n"))
+}
+
+async fn send_stream_notification(
+    outgoing: &Arc<OutgoingMessageSender>,
+    request_id: &RequestId,
+    stream: &str,
+    line: &str,
+) {
+    let params = match serde_json::to_value(OutgoingNotificationParams {
+        meta: Some(OutgoingNotificationMeta::new(Some(request_id.clone()))),
+        event: json!({
+            "type": "stream",
+            "stream": stream,
+            "line": line,
+        }),
+    }) {
+        Ok(value) => value,
+        Err(err) => {
+            error!("failed to serialize gravity-sketch notification payload: {err}");
+            return;
+        }
+    };
+
+    outgoing
+        .send_notification(OutgoingNotification {
+            method: "gravity-sketch/event".to_string(),
+            params: Some(params),
+        })
+        .await;
+}

--- a/codex-rs/mcp-server/src/tool_handlers/mod.rs
+++ b/codex-rs/mcp-server/src/tool_handlers/mod.rs
@@ -1,2 +1,1 @@
-pub(crate) mod create_conversation;
-pub(crate) mod send_message;
+pub(crate) mod gravity_sketch;

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -12,6 +12,7 @@ use tokio::process::ChildStdout;
 use anyhow::Context;
 use assert_cmd::prelude::*;
 use codex_mcp_server::CodexToolCallParam;
+use codex_mcp_server::GravitySketchToolCallParam;
 use codex_protocol::mcp_protocol::AddConversationListenerParams;
 use codex_protocol::mcp_protocol::ArchiveConversationParams;
 use codex_protocol::mcp_protocol::CancelLoginChatGptParams;
@@ -35,6 +36,7 @@ use mcp_types::JSONRPCMessage;
 use mcp_types::JSONRPCNotification;
 use mcp_types::JSONRPCRequest;
 use mcp_types::JSONRPCResponse;
+use mcp_types::ListToolsRequest;
 use mcp_types::ModelContextProtocolNotification;
 use mcp_types::ModelContextProtocolRequest;
 use mcp_types::RequestId;
@@ -211,6 +213,25 @@ impl McpProcess {
             Some(serde_json::to_value(codex_tool_call_params)?),
         )
         .await
+    }
+
+    pub async fn send_gravity_sketch_tool_call(
+        &mut self,
+        params: GravitySketchToolCallParam,
+    ) -> anyhow::Result<i64> {
+        let gravity_params = CallToolRequestParams {
+            name: "gravity-sketch".to_string(),
+            arguments: Some(serde_json::to_value(params)?),
+        };
+        self.send_request(
+            mcp_types::CallToolRequest::METHOD,
+            Some(serde_json::to_value(gravity_params)?),
+        )
+        .await
+    }
+
+    pub async fn send_list_tools_request(&mut self) -> anyhow::Result<i64> {
+        self.send_request(ListToolsRequest::METHOD, None).await
     }
 
     /// Send a `newConversation` JSON-RPC request.

--- a/codex-rs/mcp-server/tests/suite/gravity_sketch_tool.rs
+++ b/codex-rs/mcp-server/tests/suite/gravity_sketch_tool.rs
@@ -1,0 +1,328 @@
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+
+use codex_mcp_server::GravitySketchAction;
+use codex_mcp_server::GravitySketchToolCallParam;
+use mcp_test_support::McpProcess;
+use mcp_test_support::to_response;
+use mcp_types::CallToolResult;
+use mcp_types::ContentBlock;
+use mcp_types::ListToolsResult;
+use mcp_types::RequestId;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_includes_gravity_sketch() {
+    let codex_home = TempDir::new().expect("create tempdir");
+    write_basic_config(codex_home.path()).expect("write config");
+
+    let mut mcp = McpProcess::new(codex_home.path())
+        .await
+        .expect("spawn mcp process");
+    timeout(DEFAULT_TIMEOUT, mcp.initialize())
+        .await
+        .expect("initialize timeout")
+        .expect("initialize failed");
+
+    let request_id = mcp
+        .send_list_tools_request()
+        .await
+        .expect("send tools/list");
+
+    let response = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await
+    .expect("tools/list timeout")
+    .expect("tools/list response");
+
+    let result: ListToolsResult = to_response(response).expect("deserialize ListToolsResult");
+    assert!(
+        result
+            .tools
+            .iter()
+            .any(|tool| tool.name == "gravity-sketch"),
+        "tools/list should advertise gravity-sketch"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gravity_sketch_tool_success() {
+    let codex_home = TempDir::new().expect("create tempdir");
+    write_basic_config(codex_home.path()).expect("write config");
+    let cli_path = write_mock_gravity_sketch_cli(codex_home.path()).expect("write cli");
+
+    let cli_path_str = cli_path.to_string_lossy().to_string();
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[
+            ("GRAVITY_SKETCH_CLI", Some(&cli_path_str)),
+            ("GRAVITY_SKETCH_TOKEN", Some("env-token")),
+        ],
+    )
+    .await
+    .expect("spawn mcp process");
+    timeout(DEFAULT_TIMEOUT, mcp.initialize())
+        .await
+        .expect("initialize timeout")
+        .expect("initialize failed");
+
+    let params = GravitySketchToolCallParam {
+        action: GravitySketchAction::Launch,
+        host: Some("127.0.0.1".to_string()),
+        port: Some(7000),
+        token: Some("override-token".to_string()),
+        project_id: None,
+        scene_id: None,
+        export_path: None,
+        import_path: None,
+        extra_args: Vec::new(),
+        payload: Some(json!({ "sync": true })),
+        cli_path: None,
+        env: HashMap::new(),
+    };
+
+    let request_id = mcp
+        .send_gravity_sketch_tool_call(params)
+        .await
+        .expect("send gravity-sketch call");
+
+    let notification = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_notification_message("gravity-sketch/event"),
+    )
+    .await
+    .expect("gravity-sketch/event timeout")
+    .expect("gravity-sketch/event notification");
+    assert_eq!(notification.method, "gravity-sketch/event");
+    let params = notification.params.expect("gravity-sketch/event params");
+    assert_eq!(
+        params.get("type").and_then(|value| value.as_str()),
+        Some("stream"),
+        "stream notification should set type=stream"
+    );
+
+    let response = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await
+    .expect("gravity-sketch response timeout")
+    .expect("gravity-sketch response");
+
+    let result: CallToolResult = to_response(response).expect("deserialize CallToolResult");
+    assert_eq!(result.is_error, Some(false));
+    let text = match &result.content[..] {
+        [ContentBlock::TextContent(content)] => content.text.clone(),
+        other => panic!("unexpected content: {other:?}"),
+    };
+    assert!(
+        text.contains("\"status\":\"ok\""),
+        "stdout summary should include success payload"
+    );
+
+    let structured = result
+        .structured_content
+        .expect("structured_content should be populated");
+    assert_eq!(structured.get("success"), Some(&json!(true)));
+    assert!(
+        structured
+            .get("stdout")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .contains("launch:starting"),
+        "stdout should capture CLI progress"
+    );
+    assert!(
+        structured
+            .get("stderr")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .contains("connecting to Gravity Sketch"),
+        "stderr should report connection progress"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gravity_sketch_tool_failure() {
+    let codex_home = TempDir::new().expect("create tempdir");
+    write_basic_config(codex_home.path()).expect("write config");
+    let cli_path = write_mock_gravity_sketch_cli(codex_home.path()).expect("write cli");
+
+    let cli_path_str = cli_path.to_string_lossy().to_string();
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[("GRAVITY_SKETCH_CLI", Some(&cli_path_str))],
+    )
+    .await
+    .expect("spawn mcp process");
+    timeout(DEFAULT_TIMEOUT, mcp.initialize())
+        .await
+        .expect("initialize timeout")
+        .expect("initialize failed");
+
+    let mut env = HashMap::new();
+    env.insert("EXTRA_MODE".to_string(), "test".to_string());
+
+    let params = GravitySketchToolCallParam {
+        action: GravitySketchAction::ExportScene,
+        host: None,
+        port: None,
+        token: None,
+        project_id: Some("studio".to_string()),
+        scene_id: Some("scene-42".to_string()),
+        export_path: Some(codex_home.path().join("scene.usdz")),
+        import_path: None,
+        extra_args: Vec::new(),
+        payload: None,
+        cli_path: None,
+        env,
+    };
+
+    let request_id = mcp
+        .send_gravity_sketch_tool_call(params)
+        .await
+        .expect("send gravity-sketch call");
+
+    let notification = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_notification_message("gravity-sketch/event"),
+    )
+    .await
+    .expect("gravity-sketch/event timeout")
+    .expect("gravity-sketch/event notification");
+    assert_eq!(notification.method, "gravity-sketch/event");
+
+    let response = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await
+    .expect("gravity-sketch response timeout")
+    .expect("gravity-sketch response");
+
+    let result: CallToolResult = to_response(response).expect("deserialize CallToolResult");
+    assert_eq!(result.is_error, Some(true));
+    let message = match &result.content[..] {
+        [ContentBlock::TextContent(content)] => content.text.clone(),
+        other => panic!("unexpected content: {other:?}"),
+    };
+    assert!(message.contains("failed with status"));
+
+    let structured = result
+        .structured_content
+        .expect("structured_content should be populated");
+    assert_eq!(structured.get("success"), Some(&json!(false)));
+    assert_eq!(structured.get("status_code"), Some(&json!(2)));
+    assert!(
+        structured
+            .get("stderr")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .contains("missing license (test)"),
+        "stderr should include the CLI failure message"
+    );
+}
+
+fn write_basic_config(codex_home: &Path) -> std::io::Result<()> {
+    let config_toml = codex_home.join("config.toml");
+    fs::write(
+        config_toml,
+        r#"model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+"#,
+    )
+}
+
+fn write_mock_gravity_sketch_cli(dir: &Path) -> anyhow::Result<PathBuf> {
+    let script_path = dir.join("mock_gravity_sketch.sh");
+    fs::write(
+        &script_path,
+        r#"#!/bin/sh
+HOST=""
+PORT=""
+PROJECT_ID=""
+SCENE_ID=""
+EXPORT_PATH=""
+PAYLOAD=""
+ACTION=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --project-id)
+      PROJECT_ID="$2"
+      shift 2
+      ;;
+    --scene-id)
+      SCENE_ID="$2"
+      shift 2
+      ;;
+    --output)
+      EXPORT_PATH="$2"
+      shift 2
+      ;;
+    --payload)
+      PAYLOAD="$2"
+      shift 2
+      ;;
+    launch|export-scene|import-asset|open-scene|run)
+      ACTION="$1"
+      shift
+      break
+      ;;
+    *)
+      echo "unsupported flag: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$ACTION" in
+  launch)
+    echo "connecting to Gravity Sketch on ${HOST:-127.0.0.1}:${PORT:-7000}..." >&2
+    echo "launch:starting"
+    printf '{"status":"ok","action":"launch","token":"%s"}\n' "${GRAVITY_SKETCH_TOKEN:-unset}"
+    exit 0
+    ;;
+  export-scene)
+    echo "export failed: missing license (${EXTRA_MODE:-unset}) for ${SCENE_ID:-unknown} -> ${EXPORT_PATH:-unset}" >&2
+    exit 2
+    ;;
+  *)
+    echo "unsupported action: $ACTION" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )?;
+
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(&script_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms)?;
+    }
+
+    Ok(script_path)
+}

--- a/codex-rs/mcp-server/tests/suite/mod.rs
+++ b/codex-rs/mcp-server/tests/suite/mod.rs
@@ -5,6 +5,8 @@ mod codex_message_processor_flow;
 mod codex_tool;
 mod config;
 mod create_conversation;
+#[cfg(unix)]
+mod gravity_sketch_tool;
 mod interrupt;
 mod list_resume;
 mod login;

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -105,6 +105,21 @@ Property   | Type   | Description
 **`prompt`** (required)     | string | The next user prompt to continue the Codex conversation.
 **`conversationId`** (required)  | string | The id of the conversation to continue.
 
+**`gravity-sketch`** - Proxy the Gravity Sketch desktop CLI. Useful for orchestrating scene management and asset import/export workflows directly from Codex. The tool accepts:
+
+Property   | Type   | Description
+-----------|--------|---------------------------------------------------------------
+**`action`** (required) | string | Which Gravity Sketch operation to execute: `launch`, `open-scene`, `export-scene`, `import-asset`, or `custom-command`.
+`host` / `port` | string / number | Override the default local API endpoint if Gravity Sketch is exposed elsewhere.
+`token` | string | Authentication token passed through the `GRAVITY_SKETCH_TOKEN` environment variable. Falls back to the value configured on the MCP server process.
+`projectId` / `sceneId` | string | Identifiers required by `open-scene`/`export-scene` actions.
+`exportPath` / `importPath` | string | Local filesystem paths for exporting or importing content.
+`extraArgs` | array<string> | Additional CLI flags appended when `action = "custom-command"`.
+`payload` | object | Arbitrary JSON forwarded to the CLI via `--payload` for advanced automation.
+
+> [!NOTE]
+> Set `GRAVITY_SKETCH_CLI` in the MCP server environment if the Gravity Sketch executable lives outside your `$PATH`. The server streams incremental stdout/stderr updates back to the client as `gravity-sketch/event` notifications while the command runs.
+
 ### Trying it Out
 > [!TIP]
 > Codex often takes a few minutes to run. To accommodate this, adjust the MCP inspector's Request and Total timeouts to 600000ms (10 minutes) under ⛭ Configuration.

--- a/docs/config.md
+++ b/docs/config.md
@@ -372,6 +372,34 @@ env = { "API_KEY" = "value" }
 startup_timeout_ms = 20_000
 ```
 
+### Gravity Sketch MCP server
+
+Codex ships a built-in `gravity-sketch` tool that proxies the Gravity Sketch desktop application's local CLI. To expose it to Codex, add an entry such as the following to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.gravity-sketch]
+command = "codex-mcp-server"
+args = []
+env = {
+  # Point the MCP server at the Gravity Sketch CLI shim.
+  "GRAVITY_SKETCH_CLI" = "/Applications/GravitySketch.app/Contents/MacOS/gravity-sketch-cli",
+  # Provide an API token that will be injected as GRAVITY_SKETCH_TOKEN for every request.
+  "GRAVITY_SKETCH_TOKEN" = "replace-with-your-token"
+}
+startup_timeout_ms = 20_000
+```
+
+When invoking the tool, you can further customise the request via the following fields:
+
+- `action`: one of `launch`, `open-scene`, `export-scene`, `import-asset`, or `custom-command`.
+- `host` / `port`: override the default Gravity Sketch API endpoint when you are not using the local defaults.
+- `token`: per-call override for authentication (falls back to `GRAVITY_SKETCH_TOKEN`).
+- `projectId`, `sceneId`, `exportPath`, `importPath`: supply identifiers/paths required by the selected action.
+- `extraArgs`: additional CLI flags appended when using the `custom-command` action.
+- `payload`: arbitrary JSON forwarded to the CLI via `--payload`.
+
+Any keys placed under `env` in the MCP config are forwarded verbatim to the spawned Gravity Sketch CLI, allowing you to inject proxy settings or additional authentication material.
+
 You can also manage these entries from the CLI [experimental]:
 
 ```shell


### PR DESCRIPTION
## Summary
- add a Gravity Sketch tool handler that drives the local CLI, streams progress, and exposes a JSON schema
- register the new tool with the MCP message processor and document configuration details for users
- add regression tests that mock the Gravity Sketch process and validate tools/list and tools/call flows

## Testing
- cargo fmt
- cargo clippy -p codex-mcp-server --all-features
- cargo test -p codex-mcp-server --test all


------
https://chatgpt.com/codex/tasks/task_e_68d31b7ab0b08332bfa1cb7bc5941c6b